### PR TITLE
Added bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,13 @@
+{
+  "name": "bootstrap-confirmation",
+  "version": "1.0.0",
+  "main": "bootstrap-confirmation.js",
+  "keywords": [ "bootstrap", "confirm", "confirmation"],
+  "description": "Confirmation plugin compatible with Twitter Bootstrap 3 extending Popover",
+  "homepage": "https://github.com/Tavicu/bootstrap-confirmation",
+  "authors": [
+      { "name": "Octavian Ruda" }
+  ],
+  "license": "https://github.com/tavicu/bootstrap-confirmation"
+
+}


### PR DESCRIPTION
Simple bower.json file. Should just need to register on bower after
accepting this pull request per the instructions at http://bower.io/docs/creating-packages/

Guessing it will look like `bower register bootstrap-confirmation git://github.com/tavicu/bootstrap-confirmation.git`

I'll leave this for you to do so you can register it against your name if possible. 

If you haven't installed bower, node, or NPM before, it's easiest to do with chocolatey. Let me know if you'd like some help with that. 